### PR TITLE
In product.price.type do not set company_id required

### DIFF
--- a/product_price_history/product_price_history.py
+++ b/product_price_history/product_price_history.py
@@ -323,8 +323,7 @@ class price_type(orm.Model):
     _inherit = "product.price.type"
 
     _columns = {
-        'company_id': fields.many2one('res.company', 'Company',
-                                      required=True),
+        'company_id': fields.many2one('res.company', 'Company'),
     }
 
     def _get_default_company(self, cr, uid, context=None):


### PR DESCRIPTION
I set company_id optional.

I think, the context can be sufficient to know which price take. With a required company_id it is difficult to use pricelist inheritence.

For example a base price list for all my company which contains product with same price for all. And one pricelist per company with specific price for product or based on the general pricelist.
