### PR TITLE
Change labels to distinguish Cost Price from Inventory Valuation

### DIFF
--- a/product_cost_incl_bom/product_cost_incl_bom.py
+++ b/product_cost_incl_bom/product_cost_incl_bom.py
@@ -329,10 +329,8 @@ class product_product(orm.Model):
         'cost_price': fields.function(
             _cost_price,
             store=_cost_price_triggers,
-            string='Cost Price (incl. BoM)',
+            string='Cost Price',
             digits_compute=dp.get_precision('Product Price'),
-            help="The cost price is the standard price or, if the "
-                 "product has a bom, the sum of all standard price "
-                 "of its components. it take also care of the bom "
-                 "costing like cost per cycle.")
+            help="The cost that you have to support in order to produce or "
+                 "acquire the goods.")
     }

--- a/product_get_cost_field/__openerp__.py
+++ b/product_get_cost_field/__openerp__.py
@@ -19,27 +19,34 @@
 #
 ##############################################################################
 {'name': 'Product Cost field',
- 'version': '1.0.1',
+ 'version': '1.1',
  'author': 'Camptocamp',
  'maintainer': 'Camptocamp',
  'category': 'Products',
- 'complexity': "normal",  # easy, normal, expert
  'depends': [
      'product',
      ],
  'description': """
-Product Cost field
-==================
+Product Cost
+============
 
-Provides an overridable method on product which compute the cost_price field of
-a product. By default it just return the value of standard_price field, but
-using the product_cost_incl_bom module, it will return the costing from the
-bom.
+This module brings a clear distinction between the product's value and the
+cost price. The "Value" is the cost which goes in the accounting at the time
+of the yearly inventory.
+The "Cost Price" on the other hand is the cost that we have to support in
+order to produce or acquire the goods.
+Depending on your business, both prices may or may not be the same.
+
+This module adds a new cost_price field and provides an overridable method on
+product to compute it.
+By default it just returns the value of the standard_price field ("Value"),
+but optionally it could include the costing from the bill of materials
+(see product_cost_incl_bom module).
 
 As it is a generic module, you can also setup your own way of computing the
 cost_price for your product.
 
-All our modules to compute margin are based on it, so you'll ba able to use
+All OCA modules to compute margins are based on it, so you'll be able to use
 them in your own way.
 
 Contributors
@@ -53,12 +60,8 @@ Contributors
  'data': [
      'product_view.xml'
      ],
- 'demo': [],
  'test': [
      'test/cost_price_update.yml',
      ],
- 'installable': True,
- 'auto_install': False,
  'license': 'AGPL-3',
- 'application': False
  }

--- a/product_get_cost_field/i18n/fr.po
+++ b/product_get_cost_field/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-11-05 15:57+0000\n"
-"PO-Revision-Date: 2013-11-05 15:57+0000\n"
+"POT-Creation-Date: 2014-10-30 16:52+0000\n"
+"PO-Revision-Date: 2014-10-30 16:52+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,18 +16,29 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_get_cost_field
-#: help:product.product,cost_price:0
-msgid "The cost price is the standard price or, if the product has a bom, the sum of all standard price of its components. it take also care of the bom costing like cost per cylce."
-msgstr "Le prix coûtant est le prix standard ou, si le produit est défini par une nomenclature, la somme de tout les prix standard de ses composants. les coûts de la nomenclature comme le coût par cycle sont pris en compte."
+#: field:product.product,cost_price:0
+msgid "Cost Price"
+msgstr "Prix de revient"
 
 #. module: product_get_cost_field
+#: view:product.product:0
+msgid "Inventory Value"
+msgstr "Valeur d'inventaire"
+
+#. module: product_get_cost_field
+#: code:_description:0
 #: model:ir.model,name:product_get_cost_field.model_product_product
+#, python-format
 msgid "Product"
 msgstr "Article"
 
 #. module: product_get_cost_field
-#: model:ir.model.fields,field_description:product_get_cost_field.field_product_product_cost_price
-#: field:product.product,cost_price:0
-msgid "Cost Price (incl. BoM)"
-msgstr "Prix coûtant (BoM incl.)"
+#: view:product.product:0
+msgid "Valuation Method"
+msgstr "Méthode de valorisation"
+
+#. module: product_get_cost_field
+#: help:product.product,cost_price:0
+msgid "The cost that you have to support in order to produce or acquire the goods."
+msgstr "Le coût que vous devez prendre en charge pour produire ou acquerir la marchandise."
 

--- a/product_get_cost_field/i18n/product_get_cost_field.pot
+++ b/product_get_cost_field/i18n/product_get_cost_field.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-11-05 15:57+0000\n"
-"PO-Revision-Date: 2013-11-05 15:57+0000\n"
+"POT-Creation-Date: 2014-10-30 16:51+0000\n"
+"PO-Revision-Date: 2014-10-30 16:51+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,18 +16,29 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_get_cost_field
-#: help:product.product,cost_price:0
-msgid "The cost price is the standard price or, if the product has a bom, the sum of all standard price of its components. it take also care of the bom costing like cost per cylce."
+#: field:product.product,cost_price:0
+msgid "Cost Price"
 msgstr ""
 
 #. module: product_get_cost_field
+#: view:product.product:0
+msgid "Inventory Value"
+msgstr ""
+
+#. module: product_get_cost_field
+#: code:_description:0
 #: model:ir.model,name:product_get_cost_field.model_product_product
+#, python-format
 msgid "Product"
 msgstr ""
 
 #. module: product_get_cost_field
-#: model:ir.model.fields,field_description:product_get_cost_field.field_product_product_cost_price
-#: field:product.product,cost_price:0
-msgid "Cost Price (incl. BoM)"
+#: view:product.product:0
+msgid "Valuation Method"
+msgstr ""
+
+#. module: product_get_cost_field
+#: help:product.product,cost_price:0
+msgid "The cost that you have to support in order to produce or acquire the goods."
 msgstr ""
 

--- a/product_get_cost_field/product_view.xml
+++ b/product_get_cost_field/product_view.xml
@@ -8,14 +8,13 @@
       <field name="inherit_id" ref="product.product_normal_form_view" />
       <field name="arch" type="xml">
           <field name="cost_method" groups="product.group_costing_method" position="after">
-              <field name="cost_price"/> 
+              <field name="cost_price"/>
         </field>
       </field>
     </record>
 
     <record model="ir.ui.view" id="product_get_cost_field_tree">
       <field name="name">product.get_cost_field.view.tree</field>
-      <field name="type">tree</field>
       <field name="model">product.product</field>
       <field name="inherit_id" ref="product.product_product_tree_view" />
       <field name="arch" type="xml">

--- a/product_get_cost_field/product_view.xml
+++ b/product_get_cost_field/product_view.xml
@@ -3,12 +3,19 @@
   <data>
     <record model="ir.ui.view" id="product_get_cost_field_form">
       <field name="name">product.get_cost_field.view.form</field>
-      <field name="type">form</field>
       <field name="model">product.product</field>
       <field name="inherit_id" ref="product.product_normal_form_view" />
       <field name="arch" type="xml">
-          <field name="cost_method" groups="product.group_costing_method" position="after">
-              <field name="cost_price"/>
+        <!-- Add the cost price -->
+        <field name="cost_method" position="before">
+            <field name="cost_price"/> 
+        </field>
+        <!-- Rename "Cost" to "Inventory Value" -->
+        <field name="standard_price" position="attributes">
+          <attribute name="string">Inventory Value</attribute>
+        </field>
+        <field name="cost_method" position="attributes">
+            <attribute name="string">Valuation Method</attribute>
         </field>
       </field>
     </record>
@@ -18,11 +25,11 @@
       <field name="model">product.product</field>
       <field name="inherit_id" ref="product.product_product_tree_view" />
       <field name="arch" type="xml">
-        <field name="standard_price" position="after">
+        <field name="standard_price" position="before">
           <field name="cost_price"/>
         </field>
         <field name="standard_price" position="attributes">
-          <attribute name="invisible">1</attribute>
+          <attribute name="string">Inventory Value</attribute>
         </field>
       </field>
     </record>

--- a/product_stock_cost_field_report/i18n/fr.po
+++ b/product_stock_cost_field_report/i18n/fr.po
@@ -1,0 +1,36 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#   * product_stock_cost_field_report
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-10-30 17:00+0000\n"
+"PO-Revision-Date: 2014-10-30 17:00+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_stock_cost_field_report
+#: view:product.product:0
+msgid "Inventory Value"
+msgstr "Valeur d'inventaire"
+
+#. module: product_stock_cost_field_report
+#: code:_description:0
+#: model:ir.model,name:product_stock_cost_field_report.model_report_stock_move
+#, python-format
+msgid "Moves Statistics"
+msgstr "Statistiques sur les mouvements"
+
+#. module: product_stock_cost_field_report
+#: code:_description:0
+#: model:ir.model,name:product_stock_cost_field_report.model_report_stock_inventory
+#, python-format
+msgid "Stock Statistics"
+msgstr "Statistiques de stock"
+

--- a/product_stock_cost_field_report/i18n/product_stock_cost_field_report.pot
+++ b/product_stock_cost_field_report/i18n/product_stock_cost_field_report.pot
@@ -1,0 +1,36 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* product_stock_cost_field_report
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-10-30 17:00+0000\n"
+"PO-Revision-Date: 2014-10-30 17:00+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_stock_cost_field_report
+#: view:product.product:0
+msgid "Inventory Value"
+msgstr ""
+
+#. module: product_stock_cost_field_report
+#: code:_description:0
+#: model:ir.model,name:product_stock_cost_field_report.model_report_stock_move
+#, python-format
+msgid "Moves Statistics"
+msgstr ""
+
+#. module: product_stock_cost_field_report
+#: code:_description:0
+#: model:ir.model,name:product_stock_cost_field_report.model_report_stock_inventory
+#, python-format
+msgid "Stock Statistics"
+msgstr ""
+

--- a/product_stock_cost_field_report/product_stock_view.xml
+++ b/product_stock_cost_field_report/product_stock_view.xml
@@ -1,33 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
   <data>
-
-    <!-- Remove cost price to move it -->
-    <record model="ir.ui.view" id="product_get_cost_field.product_get_cost_field_form">
-      <field name="name">product.get_cost_field.view.form</field>
-      <field name="type">form</field>
-      <field name="model">product.product</field>
-      <field name="inherit_id" ref="product.product_normal_form_view" />
-      <field name="arch" type="xml">
-          <field name="cost_method" groups="product.group_costing_method" position="after">
-        </field>
-      </field>
-    </record>
-
     <record id="view_product_standard_price_form" model="ir.ui.view">
         <field name="name">product.product.standard.price.form.inherit</field>
         <field name="model">product.product</field>
         <field name="priority">20</field>
         <field name="inherit_id" ref="stock.view_product_standard_price_form"/>
         <field name="arch" type="xml">
-            <label for="standard_price" position="before">
-                <label for="cost_price" align="1.0" groups="base.group_user"/>
-                <div groups="base.group_user">
-                    <field name="cost_price" nolabel="1"/>
-                </div>
+            <label for="standard_price" position="attributes">
+              <attribute name="string">Inventory Value</attribute>
             </label>
         </field>
     </record>
-
   </data>
 </openerp>


### PR DESCRIPTION
As a workaround for odoo/odoo#3396, I think the module product_get_cost_field should change the label of product.product.standard_price to something else but "Cost price", to make it clear what each field does.
I propose to name it "Inventory Value" since it's used for stock valuation.

I also simplified the view and added a bit of documentation.

![capture du 2014-10-30 17 38 23](https://cloud.githubusercontent.com/assets/391953/4847484/430d0106-6053-11e4-93df-a733c185f4bf.png)
