### PR TITLE
[IMP] Rename cost_price to 'Replenishment cost'

### DIFF
--- a/product_cost_incl_bom/__openerp__.py
+++ b/product_cost_incl_bom/__openerp__.py
@@ -18,8 +18,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-{'name': 'Product Cost incl. BOM',
- 'version': '1.0',
+{'name': 'Replenishment Cost incl. BOM',
+ 'version': '1.1',
  'author': 'Camptocamp',
  'maintainer': 'Camptocamp',
  'category': 'Products',
@@ -28,14 +28,14 @@
              'mrp',
              ],
  'description': """
-Product Cost including BOM costs
-================================
+Replenishment Cost including BOM costs
+======================================
 
-Compute product cost price by recursively summing parts cost prices according
-to product BOM. It takes into account the BoM costing (cost per cycle and
-so...). If no BOM define for a product, the cost_price is always equal to the
-standard_price field of the product, so we always have a value to base our
-reporting on.
+Compute product's Replenishment cost by recursively summing the Replenishment
+costs of the parts according to product BOM. It takes into account the BoM
+costing (cost per cycle and so...). If no BOM define for a product,
+the Replenishment cost is always equal to the Cost price of the product,
+so we always have a value to base our reporting on.
 
 The computed value is stored in the DB and can be used in 3rd party report.
 

--- a/product_cost_incl_bom/product_cost_incl_bom.py
+++ b/product_cost_incl_bom/product_cost_incl_bom.py
@@ -107,7 +107,7 @@ class product_product(orm.Model):
         The price of all theses products are computed at the same
         time in this function, the effect is that we should take:
 
-        1. to not read the cost price of a product in the browse_record,
+        1. to not read the cost of a product in the browse_record,
            if it is computed here because it has likely changed, but use
            the new cost instead
         2. compute the prices in a topological order, so we start at the
@@ -184,7 +184,7 @@ class product_product(orm.Model):
         for product_id in ordered:
             if product_id not in ids:
                 # the product is a dependency so it appears in the
-                # topological sort, but the cost price should not be
+                # topological sort, but the cost should not be
                 # recomputed
                 continue
             if product_id not in product_bom:
@@ -196,7 +196,7 @@ class product_product(orm.Model):
             for subproduct_info in subproduct_infos:
                 subproduct_id = subproduct_info['product_id']
                 subproduct = subproduct_costs[subproduct_id]
-                # The cost price could have been recomputed in an
+                # The cost could have been recomputed in an
                 # earlier iteration.  Thanks to the topological sort,
                 # the subproducts are always computed before their
                 # parents
@@ -329,10 +329,12 @@ class product_product(orm.Model):
         'cost_price': fields.function(
             _cost_price,
             store=_cost_price_triggers,
-            string='Cost Price (incl. BoM)',
+            string='Replenishment cost',
             digits_compute=dp.get_precision('Product Price'),
-            help="The cost price is the standard price or, if the "
-                 "product has a bom, the sum of all standard price "
-                 "of its components. it take also care of the bom "
-                 "costing like cost per cycle.")
+            help="The cost that you have to support in order to produce or "
+                 "acquire the goods. Depending on the modules installed, "
+                 "this cost may be computed based on various pieces of "
+                 "information, for example Bills of Materials or latest "
+                 "Purchases. By default, the Replenishment cost is the same "
+                 "as the Cost Price.")
     }

--- a/product_cost_incl_bom_price_history/__openerp__.py
+++ b/product_cost_incl_bom_price_history/__openerp__.py
@@ -21,20 +21,20 @@
 ##############################################################################
 
 {
-    "name": "Product Cost incl. BoM and Price History",
-    "version": "1.2",
+    "name": "Replenishment Cost incl. BoM and Price History",
+    "version": "1.3",
     "author": "Camptocamp",
     "category": "Generic Modules/Inventory Control",
     "depends": ["product_cost_incl_bom",
                 "product_price_history",
                 ],
     "description": """
-Product Cost incl. BoM and Price History
-========================================
+Replenishment Cost incl. BoM and Price History
+==============================================
 
 This module make the glue between product_cost_incl_bom and
-product_price_history and allow to have your cost price computed from the
-component of the BoM, while having it also historized by company.
+product_price_history and allow to have your Replenishment cost computed from
+the component of the BoM, while having it also historized by company.
 
 It display now this value for the inventory valuation provided by
 product_price_history module.

--- a/product_cost_incl_bom_price_history/product.py
+++ b/product_cost_incl_bom_price_history/product.py
@@ -222,11 +222,14 @@ class product_product(orm.Model):
         'cost_price': fields.function(
             _cost_price,
             store=_cost_price_triggers,
-            string='Cost Price (incl. BoM)',
+            string='Replenishment cost',
             digits_compute=dp.get_precision('Product Price'),
-            help="The cost price is the standard price or, if the product has "
-                 "a bom, the sum of all standard price of its components. it "
-                 "take also care of the bom costing like cost per cylce."),
+            help="The cost that you have to support in order to produce or "
+                 "acquire the goods. Depending on the modules installed, "
+                 "this cost may be computed based on various pieces of "
+                 "information, for example Bills of Materials or latest "
+                 "Purchases. By default, the Replenishment cost is the same "
+                 "as the Cost Price."),
         'value_available': fields.function(
             _product_value,
             type='float', digits_compute=dp.get_precision('Product Price'),

--- a/product_get_cost_field/__openerp__.py
+++ b/product_get_cost_field/__openerp__.py
@@ -18,28 +18,27 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-{'name': 'Product Cost field',
- 'version': '1.0.1',
+{'name': 'Replenishment cost',
+ 'version': '1.0.3',
  'author': 'Camptocamp',
  'maintainer': 'Camptocamp',
  'category': 'Products',
- 'complexity': "normal",  # easy, normal, expert
  'depends': [
      'product',
      ],
  'description': """
-Product Cost field
-==================
+Product Replenishment Cost
+==========================
 
-Provides an overridable method on product which compute the cost_price field of
-a product. By default it just return the value of standard_price field, but
+Provides an overridable method on product which compute the Replenishment cost
+of a product. By default it just returns the value of "Cost price" field, but
 using the product_cost_incl_bom module, it will return the costing from the
 bom.
 
 As it is a generic module, you can also setup your own way of computing the
 cost_price for your product.
 
-All our modules to compute margin are based on it, so you'll ba able to use
+All OCA modules to compute margins are based on it, so you'll be able to use
 them in your own way.
 
 Contributors
@@ -53,12 +52,8 @@ Contributors
  'data': [
      'product_view.xml'
      ],
- 'demo': [],
  'test': [
      'test/cost_price_update.yml',
      ],
- 'installable': True,
- 'auto_install': False,
  'license': 'AGPL-3',
- 'application': False
  }

--- a/product_get_cost_field/i18n/fr.po
+++ b/product_get_cost_field/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-11-05 15:57+0000\n"
-"PO-Revision-Date: 2013-11-05 15:57+0000\n"
+"POT-Creation-Date: 2014-10-30 16:52+0000\n"
+"PO-Revision-Date: 2014-10-30 16:52+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,18 +16,19 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_get_cost_field
-#: help:product.product,cost_price:0
-msgid "The cost price is the standard price or, if the product has a bom, the sum of all standard price of its components. it take also care of the bom costing like cost per cylce."
-msgstr "Le prix coûtant est le prix standard ou, si le produit est défini par une nomenclature, la somme de tout les prix standard de ses composants. les coûts de la nomenclature comme le coût par cycle sont pris en compte."
+#: field:product.product,cost_price:0
+msgid "Replenishment cost"
+msgstr "Coût de réapprovisionnement"
 
 #. module: product_get_cost_field
+#: code:_description:0
 #: model:ir.model,name:product_get_cost_field.model_product_product
+#, python-format
 msgid "Product"
 msgstr "Article"
 
 #. module: product_get_cost_field
-#: model:ir.model.fields,field_description:product_get_cost_field.field_product_product_cost_price
-#: field:product.product,cost_price:0
-msgid "Cost Price (incl. BoM)"
-msgstr "Prix coûtant (BoM incl.)"
+#: help:product.product,cost_price:0
+msgid "The cost that you have to support in order to produce or acquire the goods. Depending on the modules installed, this cost may be computed based on various pieces of information, for example Bills of Materials or latest Purchases. By default, the Replenishment cost is the same as the Cost Price."
+msgstr "Le coût que vous devez prendre en charge pour produire ou acquerir la marchandise. Selon les modules installés, le calcul de ce coût peut s'appuyer sur diverses informations : par exemple les nomenclatures ou les derniers achats. Par défaut, le coût de réapprovisionnement est le même que le Prix de revient."
 

--- a/product_get_cost_field/i18n/product_get_cost_field.pot
+++ b/product_get_cost_field/i18n/product_get_cost_field.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-11-05 15:57+0000\n"
-"PO-Revision-Date: 2013-11-05 15:57+0000\n"
+"POT-Creation-Date: 2014-10-30 16:51+0000\n"
+"PO-Revision-Date: 2014-10-30 16:51+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,18 +16,19 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_get_cost_field
-#: help:product.product,cost_price:0
-msgid "The cost price is the standard price or, if the product has a bom, the sum of all standard price of its components. it take also care of the bom costing like cost per cylce."
+#: field:product.product,cost_price:0
+msgid "Replenishment cost"
 msgstr ""
 
 #. module: product_get_cost_field
+#: code:_description:0
 #: model:ir.model,name:product_get_cost_field.model_product_product
+#, python-format
 msgid "Product"
 msgstr ""
 
 #. module: product_get_cost_field
-#: model:ir.model.fields,field_description:product_get_cost_field.field_product_product_cost_price
-#: field:product.product,cost_price:0
-msgid "Cost Price (incl. BoM)"
+#: help:product.product,cost_price:0
+msgid "The cost that you have to support in order to produce or acquire the goods. Depending on the modules installed, this cost may be computed based on various pieces of information, for example Bills of Materials or latest Purchases. By default, the Replenishment cost is the same as the Cost Price."
 msgstr ""
 

--- a/product_get_cost_field/product_get_cost_field.py
+++ b/product_get_cost_field/product_get_cost_field.py
@@ -29,6 +29,8 @@ class product_product(orm.Model):
     _inherit = 'product.product'
 
     def _compute_purchase_price(self, cr, uid, ids, context=None):
+        """"Use standard_price's value for cost_price"""
+        # TODO: merge with _cost_price in v8, use new API
         res = {}
         if isinstance(ids, (int, long)):
             ids = [ids]
@@ -39,21 +41,26 @@ class product_product(orm.Model):
         return res
 
     def _cost_price(self, cr, uid, ids, field_name, arg, context=None):
-        if context is None:
-            context = {}
+        """"Proxy method to make the function field modular
+
+        Submodules have only to override _compute_purchase_price(), without
+        having to redefine the whole function field"""
+        # TODO: merge with _compute_purchase_price  in v8, use new API
         return self._compute_purchase_price(cr, uid, ids, context=context)
 
     def get_cost_field(self, cr, uid, ids, context=None):
         return self._cost_price(cr, uid, ids, '', [], context=context)
 
     def _get_product_from_template(self, cr, uid, ids, context=None):
+        """Find the products to trigger when a template changes"""
+        # self may be product template so we need to lookup the pool
         prod_obj = self.pool.get('product.product')
         prod_ids = prod_obj.search(cr, uid,
                                    [('product_tmpl_id', 'in', ids)],
                                    context=context)
         return prod_ids
 
-    # Trigger on product.product is set to None, otherwise do not trigg
+    # Trigger on product.product is set to None, otherwise do not trigger
     # on product creation !
     _cost_price_triggers = {
         'product.product': (lambda self, cr, uid, ids, context=None:
@@ -67,8 +74,12 @@ class product_product(orm.Model):
         'cost_price': fields.function(
             _cost_price,
             store=_cost_price_triggers,
-            string='Cost Price',
+            string='Replenishment cost',
             digits_compute=dp.get_precision('Product Price'),
-            help="The cost price is the standard price unless you install the "
-                 "product_cost_incl_bom module.")
+            help="The cost that you have to support in order to produce or "
+                 "acquire the goods. Depending on the modules installed, "
+                 "this cost may be computed based on various pieces of "
+                 "information, for example Bills of Materials or latest "
+                 "Purchases. By default, the Replenishment cost is the same "
+                 "as the Cost Price.")
     }

--- a/product_get_cost_field/product_view.xml
+++ b/product_get_cost_field/product_view.xml
@@ -7,6 +7,7 @@
       <field name="model">product.product</field>
       <field name="inherit_id" ref="product.product_normal_form_view" />
       <field name="arch" type="xml">
+        <!-- Add the Replenishment cost -->
           <field name="cost_method" groups="product.group_costing_method" position="after">
               <field name="cost_price"/> 
         </field>

--- a/product_stock_cost_field_report/__openerp__.py
+++ b/product_stock_cost_field_report/__openerp__.py
@@ -18,7 +18,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-{'name': 'Product Cost field Report',
+{'name': 'Replenishment Cost Report',
  'version': '1.0',
  'author': 'Camptocamp',
  'maintainer': 'Camptocamp',
@@ -28,12 +28,13 @@
              'stock',
              ],
  'description': """
-Product Cost field Report
+Replenishment Cost Report
 =========================
 
 This module override the reporting view of OpenERP to replace the
-standard_price field used by the new cost_price one. This way all reporting of
-OpenERP will now take this field into account and display the correct result.
+Cost price field used with the Replenishment cost one. This way all reporting
+of OpenERP will now take this field into account and display the correct
+result.
 
 We're talking here about the reporting found under: Reporting -> Warehouse
 

--- a/product_stock_cost_field_report/report_stock_move.py
+++ b/product_stock_cost_field_report/report_stock_move.py
@@ -27,7 +27,7 @@ class report_stock_move(orm.Model):
 
     def init(self, cr):
         """
-        Override the SQL view tpo replace standard_price by cost_price
+        Override the SQL view to replace standard_price by cost_price
         """
         tools.drop_view_if_exists(cr, 'report_stock_move')
         cr.execute("""
@@ -104,7 +104,7 @@ class report_stock_inventory(orm.Model):
 
     def init(self, cr):
         """
-        Override the SQL view tpo replace standard_price by cost_price
+        Override the SQL view to replace standard_price by cost_price
         """
         tools.drop_view_if_exists(cr, 'report_stock_inventory')
         cr.execute("""


### PR DESCRIPTION
Fixes #6
This change is meant as a short-term solution, to avoid confusion between standard_price and cost_price since both are named 'Cost Price' in the GUI.
The accounting best practises seem to be that if a Cost price is known, it must be used for the valuation of the stock. So the right 'Cost price' field is standard_price and we have to name cost_price something else.
The description of the inherited fields is changed too, because for some reason the server seems unable to export the new names in the .po files.
