### PR TITLE
product_price_history: use force_company if it is in context

### DIFF
--- a/product_price_history/product_price_history.py
+++ b/product_price_history/product_price_history.py
@@ -230,14 +230,14 @@ class product_template(orm.Model):
         allow other module to give the proper company_id in the context (like
         it's done in product_standard_margin for example).
 
+        If force_company is in context, use it in prioriy.
+
         If company_id not in context, take the one from uid.
         """
-        res = uid
         if context is None:
             context = {}
-        if context.get('company_id'):
-            res = context.get('company_id')
-        else:
+        res = context.get('force_company') or context.get('company_id')
+        if not res:
             user_obj = self.pool.get('res.users')
             res = user_obj.read(cr, uid, uid,
                                 ['company_id'],


### PR DESCRIPTION
When a reception is done, odoo compute the standard price with product.price_get(). In this method a browse on product is done with SUPERUSER_ID. In this browse, odoo append 'force_company' in the context.
The current context, is not passed in all case, so it is possible to loose company_id.

If the current test : avg_price_computation_mutlicompanies_multicurrencies.yml is used with any currency, it shows the problem.
