### PR TITLE
[7.0] [product cost_incl_bom] fix work order cost

### DIFF
--- a/product_cost_incl_bom/product_cost_incl_bom.py
+++ b/product_cost_incl_bom/product_cost_incl_bom.py
@@ -213,9 +213,7 @@ class product_product(orm.Model):
                 for wline in bom.routing_id.workcenter_lines:
                     wc = wline.workcenter_id
                     cycle = wline.cycle_nbr
-                    hour = ((wc.time_start + wc.time_stop +
-                             cycle * wc.time_cycle) *
-                            (wc.time_efficiency or 1.0))
+                    hour = wline.hour_nbr
                     cost += wc.costs_cycle * cycle + wc.costs_hour * hour
             cost /= bom.product_qty
 

--- a/product_cost_incl_bom/product_cost_incl_bom.py
+++ b/product_cost_incl_bom/product_cost_incl_bom.py
@@ -214,6 +214,7 @@ class product_product(orm.Model):
                     wc = wline.workcenter_id
                     cycle = wline.cycle_nbr
                     hour = wline.hour_nbr
+
                     cost += wc.costs_cycle * cycle + wc.costs_hour * hour
             cost /= bom.product_qty
 

--- a/product_cost_incl_bom/product_cost_incl_bom.py
+++ b/product_cost_incl_bom/product_cost_incl_bom.py
@@ -214,7 +214,6 @@ class product_product(orm.Model):
                     wc = wline.workcenter_id
                     cycle = wline.cycle_nbr
                     hour = wline.hour_nbr
-
                     cost += wc.costs_cycle * cycle + wc.costs_hour * hour
             cost /= bom.product_qty
 


### PR DESCRIPTION
This PR fixes an incorrect calculation of the cost associated to BOM's. 
The cost of the work order is basically the number of cycles \* cost of cycle indicated in the workcenter +  hours indicated in the work order \* hourly cost of the workcenter.

At least this is how it is calculated in the "Product Cost Structure" report that can be printed from the product form.

I don't really understand why was the previous formula used:
hour = ((wc.time_start + wc.time_stop + cycle \* wc.time_cycle) \* (wc.time_efficiency or 1.0))

This formula is not used in the Product Cost Structure report at all. 

The results shown in the Product Cost Structure report and the Replenishment cost field should match in the resulting value.

Regards,
Jordi.
