### PR TITLE
BoM price history: correct call to store function

### DIFF
--- a/product_cost_incl_bom_price_history/product.py
+++ b/product_cost_incl_bom_price_history/product.py
@@ -111,8 +111,8 @@ class product_product(orm.Model):
         return res
 
     def _get_product2(self, cr, uid, ids, context=None):
-        mrp_obj = self.pool.get('mrp.bom')
-        res = mrp_obj._get_product(cr, uid, ids, context=context)
+        prod_obj = self.pool.get('product.product')
+        res = prod_obj._get_product(cr, uid, ids, context=context)
         return res
 
     def _get_bom_product2(self, cr, uid, ids, context=None):


### PR DESCRIPTION
PR to fix an issue with the store condition: the super called was `mrp.bom.get_product` , but the function in `product_cost_incl_bom` is on the `product.product` object.
