### PR TITLE
[11.0][IMP] sale_margin_delivered: Avoid use product_uom_qty to compute delivered margin. Other module tests fails

### DIFF
--- a/sale_margin_delivered/models/sale_margin.py
+++ b/sale_margin_delivered/models/sale_margin.py
@@ -49,8 +49,9 @@ class SaleOrderLine(models.Model):
                                  line.qty_delivered) or line.purchase_price
                 line.purchase_price_delivery = tools.float_round(
                     average_price, precision_digits=digits)
-                line.margin_delivered = (
-                    line.qty_delivered * line.margin / line.product_uom_qty)
+                line.margin_delivered = line.qty_delivered * (
+                    line.price_reduce - line.purchase_price_delivery
+                )
             # compute percent margin based on delivered quantities or ordered
             # quantities
             line.margin_delivered_percent = qty and (


### PR DESCRIPTION
cc @Tecnativa