### PR TITLE
[9.0][FIX] move demo xml from data to demo

### DIFF
--- a/product_replenishment_cost/__openerp__.py
+++ b/product_replenishment_cost/__openerp__.py
@@ -30,6 +30,8 @@
     'website': 'http://www.camptocamp.com/',
     'data': [
         'views/product_view.xml',
+    ],
+    'demo': [
         'demo/res_groups.yml',
     ],
     'test': [


### PR DESCRIPTION
trivial fix. 
in product_replenishment_cost, the demo file is in 'data' key, in the manifest. Moving in the demo key.