### PR TITLE
[FIX] stored field should not depend on none stored field

### DIFF
--- a/product_standard_margin/models/product_product.py
+++ b/product_standard_margin/models/product_product.py
@@ -43,8 +43,8 @@ class ProductProduct(models.Model):
 
     # Compute Section
     @api.depends(
-        "lst_price",
         "product_tmpl_id.list_price",
+        "product_tmpl_id.price_attribute_value_ids.price_extra",
         "standard_price",
         "taxes_id.price_include",
         "taxes_id.amount",

--- a/product_standard_margin/models/product_template.py
+++ b/product_standard_margin/models/product_template.py
@@ -37,10 +37,14 @@ class ProductTemplate(models.Model):
         "Take care of tax include and exclude.. If no sale price "
         "set, will display 999.0",
     )
+    price_attribute_value_ids = fields.One2many(
+        "product.template.attribute.value",
+        "product_tmpl_id",
+        )
 
     # Compute Section
     @api.depends(
-        "lst_price",
+        "list_price",
         "standard_price",
         "taxes_id.price_include",
         "taxes_id.amount",


### PR DESCRIPTION
if a stored field depend on a non stored field, really weird behaviour
can occure.
Indeed none-stored field can not be searched correctly and the ORM will
return all product (with an empty domain).
So in my case I import data through csv field one product.template.attribute.value
it will recompute the standard price on all product of my database !