### PR TITLE
[12.0][FIX] sale_margin_delivered: Force company for SO in tests

### DIFF
--- a/sale_margin_delivered/tests/test_sale_margin_delivered.py
+++ b/sale_margin_delivered/tests/test_sale_margin_delivered.py
@@ -39,7 +39,8 @@ class TestSaleMarginDelivered(SavepointCase):
         })
 
     def _new_sale_order(self):
-        sale_order = self.SaleOrder.new({
+        vals = self.SaleOrder.default_get(self.SaleOrder._fields.keys())
+        vals.update({
             'date_order': datetime.today(),
             'name': 'Test_SO011',
             'order_line': [
@@ -51,6 +52,7 @@ class TestSaleMarginDelivered(SavepointCase):
             ],
             'partner_id': self.partner.id,
         })
+        sale_order = self.SaleOrder.new(vals)
         sale_order.onchange_partner_id()
         return self.SaleOrder.create(
             sale_order._convert_to_write(sale_order._cache))


### PR DESCRIPTION
The default is not being applied because of the `new`/`create` approach.
If some other module in the chain needs that field, tests will fail.
This forces the same company that is applied by default: https://github.com/odoo/odoo/blob/12.0/addons/sale/models/sale.py#L228

@Tecnativa
TT31040

ping @pedrobaeza @sergio-teruel 