### PR TITLE
[FIX] sale_margin_delivered: non storable

### DIFF
--- a/sale_margin_delivered/__manifest__.py
+++ b/sale_margin_delivered/__manifest__.py
@@ -9,7 +9,7 @@
     "category": "Sales",
     "license": "AGPL-3",
     "depends": [
-        "stock",
+        "sale_stock",
         "sale_margin_security",
     ],
     "data": [


### PR DESCRIPTION
We don't want to compute margin based on stock moves for non storable
products. This specially true for services and kits.

cc @Tecnativa TT33499

What do you think @sergio-teruel @carlosdauden ?