### PR TITLE
[IMP] product_margin_classification : display classification ordered by name, instead of by id

### DIFF
--- a/product_margin_classification/models/product_margin_classification.py
+++ b/product_margin_classification/models/product_margin_classification.py
@@ -11,6 +11,7 @@ import odoo.addons.decimal_precision as dp
 class ProductMarginClassification(models.Model):
     _name = "product.margin.classification"
     _description = "Product Margin Classification"
+    _order = "name"
 
     # Column Section
     name = fields.Char(string="Name", required=True)


### PR DESCRIPTION
Trivial PR.

display margin classificiation order by name, and not by id. (creation date).