### PR TITLE
[12.0][FIX] product_pricelist_margin : change dependency 

### DIFF
--- a/product_pricelist_margin/__manifest__.py
+++ b/product_pricelist_margin/__manifest__.py
@@ -10,7 +10,7 @@
     "maintainers": ["legalsylvain"],
     "website": "https://github.com/OCA/margin-analysis",
     "license": "AGPL-3",
-    "depends": ["sale"],
+    "depends": ["account"],
     "data": [
         "views/view_product_template.xml",
         "wizards/wizard_preview_pricelist_margin.xml",


### PR DESCRIPTION
following @pedrobaeza : I checked and installed the module. ``product_pricelist_margin``. changing the dependency from 'sale' to 'account' is working. (https://github.com/OCA/product-attribute/pull/1101#issuecomment-1176251703)

