### PR TITLE
[14.0][FIX] account_invoice_margin: Take currency into account

### DIFF
--- a/account_invoice_margin/models/account_invoice.py
+++ b/account_invoice_margin/models/account_invoice.py
@@ -113,6 +113,14 @@ class AccountMoveLine(models.Model):
                     purchase_price = line.product_id.uom_id._compute_price(
                         purchase_price, line.product_uom_id
                     )
-                line.purchase_price = purchase_price
+                move = line.move_id
+                company = move.company_id or self.env.company
+                line.purchase_price = company.currency_id._convert(
+                    purchase_price,
+                    move.currency_id,
+                    company,
+                    move.invoice_date or fields.Date.today(),
+                    round=False,
+                )
             else:
                 line.purchase_price = 0.0


### PR DESCRIPTION
The invoice may be done in a currency different from the company currency, so the cost (purchase_price) amount will be incorrect in such context.

Forward-port of #138 

@Tecnativa TT38500