### PR TITLE
[FIX] product_standard_margin

### DIFF
--- a/product_standard_margin/views/view_product_product.xml
+++ b/product_standard_margin/views/view_product_product.xml
@@ -13,8 +13,8 @@
                 position="after"
             >
                 <field name="standard_margin" widget="monetary" />
-                <field name="standard_margin_rate" widget="percentpie" />
-                <field name="standard_markup_rate" widget="percentpie" />
+                <field name="standard_margin_rate" />
+                <field name="standard_markup_rate" />
             </xpath>
         </field>
     </record>
@@ -28,8 +28,8 @@
             </field>
             <field name="standard_price" position="before">
                 <field name="standard_margin" widget="monetary" />
-                <field name="standard_margin_rate" widget="percentpie" />
-                <field name="standard_markup_rate" widget="percentpie" />
+                <field name="standard_margin_rate" />
+                <field name="standard_markup_rate" />
             </field>
         </field>
     </record>

--- a/product_standard_margin/views/view_product_template.xml
+++ b/product_standard_margin/views/view_product_template.xml
@@ -16,12 +16,10 @@
                 />
                 <field
                     name="standard_margin_rate"
-                    widget="percentpie"
                     attrs="{'invisible': [('product_variant_count', '>', 1)]}"
                 />
                 <field
                     name="standard_markup_rate"
-                    widget="percentpie"
                     attrs="{'invisible': [('product_variant_count', '>', 1)]}"
                 />
             </xpath>


### PR DESCRIPTION
Hi!

After testing the module, the 'percentpie' widget does not work as expected when it has 3 digits. Moreover, in v16 it is hardly used, so I do not see the need to add it and follow the line that is followed in the version.

![Captura de pantalla de 2023-07-24 11-31-50](https://github.com/OCA/margin-analysis/assets/110393853/8ec6dcca-f212-42e2-b3bf-cde9cf904787)

This PR only removes the 'percentpie' widget from the views of this module.