### PR TITLE
[16.0][FIX]sale_margin_security: allow sale.order duplication

### DIFF
--- a/sale_margin_security/models/sale_order.py
+++ b/sale_margin_security/models/sale_order.py
@@ -21,5 +21,5 @@ class SaleOrderLine(models.Model):
         groups="sale_margin_security.group_sale_margin_security"
     )
     purchase_price = fields.Float(
-        groups="sale_margin_security.group_sale_margin_security"
+        groups="sale_margin_security.group_sale_margin_security", copy=False
     )


### PR DESCRIPTION
Users without the "sale_margin_security.group_sale_margin_security" permission group can not duplicate sale.order records due to a permission error. This PR avoids that error setting Copy=False in that inherited field's inheritance.

![image](https://github.com/OCA/margin-analysis/assets/45785416/27353f99-1b62-48c7-8b2c-596c92dea1d2)

Extended explanation:

The purchase_price field has:
-  A default value of Copy=True (because it is defined on the Odoo sale_margin module with readonly=False). When a user 
- A groups parameter  = 'sale_margin_security.group_sale_margin_security'

When a user without the 'sale_margin_security.group_sale_margin_security' tries to copy a record of the model, an error is shown because Odoo tries to access to the field with the salesman user but it does not have the permission

The purchase_price has a computed default value, and the case of manually editing it is not common; so setting copy=False on the field and priorizing the compute over the manual changes should not be a problem