### PR TITLE
[FIX] use lst_price for _compute_margin in product.product

### DIFF
--- a/product_standard_margin/models/product_product.py
+++ b/product_standard_margin/models/product_product.py
@@ -52,7 +52,7 @@ class ProductProduct(models.Model):
 
     # Compute Section
     @api.depends(
-        "list_price",
+        "lst_price",
         "product_tmpl_id.list_price",
         "standard_price",
         "taxes_id.price_include",
@@ -62,7 +62,7 @@ class ProductProduct(models.Model):
     def _compute_margin(self):
         for product in self:
             product.list_price_vat_excl = product.taxes_id.compute_all(
-                product.list_price, product=product
+                product.lst_price, product=product
             )["total_excluded"]
             product.standard_margin = (
                 product.list_price_vat_excl - product.standard_price

--- a/product_standard_margin/tests/test_module.py
+++ b/product_standard_margin/tests/test_module.py
@@ -14,18 +14,19 @@ class TestModule(TransactionCase):
 
     # Custom Section
     def _create_product(self, model, standard_price, sale_price, sale_tax_ids):
+        vals = {
+            "name": "Demo Product",
+            "standard_price": standard_price,
+            "taxes_id": [(6, 0, sale_tax_ids)],
+        }
         if model == "product":
             ModelObj = self.ProductProduct
+            vals.update({"lst_price": sale_price})
         else:
             ModelObj = self.ProductTemplate
-        return ModelObj.create(
-            {
-                "name": "Demo Product",
-                "standard_price": standard_price,
-                "list_price": sale_price,
-                "taxes_id": [(6, 0, sale_tax_ids)],
-            }
-        )
+            vals.update({"list_price": sale_price})
+
+        return ModelObj.create(vals)
 
     # Test Section
     def test_01_classic_margin(self):


### PR DESCRIPTION
The margin calculation functions correctly for products without variants.
However, there is an issue with the calculation for products that have variants.

![Screenshot at Jan 03 10-36-00](https://github.com/OCA/margin-analysis/assets/7898318/f6d55ba5-590f-4c71-97e4-99bdfcf0bc60)

**Expected behavior**

![Screenshot at Jan 03 10-35-39](https://github.com/OCA/margin-analysis/assets/7898318/eec68ec7-0f4d-4d75-a214-986e8fc9615b)
