### PR TITLE
[FIX] account_invoice_margin_sale: error creating invoice from sale order

### DIFF
--- a/account_invoice_margin_sale/models/sale.py
+++ b/account_invoice_margin_sale/models/sale.py
@@ -10,5 +10,5 @@ class SaleOrderLine(models.Model):
 
     def _prepare_invoice_line(self, **optional_values):
         vals = super()._prepare_invoice_line(**optional_values)
-        vals["purchase_price"] = self.purchase_price
+        vals["purchase_price"] = self.sudo().purchase_price
         return vals

--- a/account_invoice_margin_sale/readme/CONTRIBUTORS.rst
+++ b/account_invoice_margin_sale/readme/CONTRIBUTORS.rst
@@ -7,6 +7,7 @@
 * `Open Source Integrators <https://www.opensourceintegrators.com>`__:
 
   * Bhavesh Odedra
+  * Daniel Reis <dreis@opensourceintegrators.com>
 
 * `Factor Libre <https://www.factorlibre.com>`__:
 


### PR DESCRIPTION
When sale_margin_security is also installed.
Closes https://github.com/OCA/margin-analysis/issues/194
