### PR TITLE
[16.0][IMP] product_margin_classification: set default company

### DIFF
--- a/product_margin_classification/models/product_margin_classification.py
+++ b/product_margin_classification/models/product_margin_classification.py
@@ -87,7 +87,7 @@ class ProductMarginClassification(models.Model):
     # Default Section
     @api.model
     def _default_company_id(self):
-        return self.env.user.company_id.id
+        return self.env.company.id
 
     @api.model
     def _default_price_round(self):


### PR DESCRIPTION
Correctly transfer the default company and not the user's company.