### PR TITLE
[14.0][FIX] account_invoice_margin: wrong default margin calculation

### DIFF
--- a/account_invoice_margin/hooks.py
+++ b/account_invoice_margin/hooks.py
@@ -43,6 +43,7 @@ def pre_init_hook(cr):
             FROM account_move_line
             INNER JOIN account_move
             ON account_move.id = account_move_line.move_id
+            WHERE account_move_line.exclude_from_invoice_tab = false
             GROUP BY account_move_line.move_id
         )
         UPDATE account_move


### PR DESCRIPTION
When installing the module, the Invoice total margin initial calculation
was including all AML lines, including taxes.
This resulted in a margin of more than 100%.

Example:
![image](https://github.com/OCA/margin-analysis/assets/1246629/3c6b46df-5438-473b-98eb-1a48842715a5)
