### PR TITLE
[16.0][IMP] product_margin_classification: modify registration rule to solve multi-company error

### DIFF
--- a/product_margin_classification/security/ir_rule.xml
+++ b/product_margin_classification/security/ir_rule.xml
@@ -13,9 +13,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             ref="product_margin_classification.model_product_margin_classification"
         />
         <field name="global" eval="True" />
-        <field
-            name="domain_force"
-        >['|', ('company_id', '=', user.company_id.id), ('company_id','=',False)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
Working with classification margins, when we have a multi-company user when changing companies and trying to create a classification margin the following error occurs:


![error](https://github.com/OCA/margin-analysis/assets/82393040/455f8a11-5d5b-472e-ac74-a8f1a6757ae6)


If the domain of the registration rule is modified, the problem is solved