### PR TITLE
[FIX] [16.0] sale_margin_delivered: Fix calculation when more quantities are sent than ordered

### DIFF
--- a/sale_margin_delivered/README.rst
+++ b/sale_margin_delivered/README.rst
@@ -92,6 +92,9 @@ Contributors
   * Carlos Roca
   * Pilar Vargas
 
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
+* Rafael Blasco (`Moduon <https://www.moduon.team/>`__)
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/sale_margin_delivered/i18n/es.po
+++ b/sale_margin_delivered/i18n/es.po
@@ -4,34 +4,45 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-09 08:52+0000\n"
-"PO-Revision-Date: 2023-10-09 09:14+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
+"POT-Creation-Date: 2024-05-31 07:23+0000\n"
+"PO-Revision-Date: 2024-05-31 09:30+0200\n"
+"Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#. module: sale_margin_delivered
+#: model:ir.model.fields,help:sale_margin_delivered.field_sale_order_line__purchase_price_delivery
+msgid ""
+"Average Unit Cost of delivered products.\n"
+"\n"
+"Formula: Value Delivered / Quantity Delivered"
+msgstr ""
+"Promedio del Coste Unitario de los productos entregados.\n"
+"\n"
+"Fórmula: Valor entregado / Cantidad Entregada"
 
 #. module: sale_margin_delivered
 #: model_terms:ir.ui.view,arch_db:sale_margin_delivered.view_order_form
 msgid "Cost Price dlvd."
-msgstr "Coste de lo entregado."
+msgstr "Coste entr."
 
 #. module: sale_margin_delivered
 #: model:ir.model.fields,field_description:sale_margin_delivered.field_sale_order_line__margin_delivered
 #: model:ir.model.fields,field_description:sale_margin_delivered.field_sale_report__margin_delivered
 msgid "Margin Delivered"
-msgstr "Margen de lo entregado"
+msgstr "Margen entr."
 
 #. module: sale_margin_delivered
 #: model:ir.model.fields,field_description:sale_margin_delivered.field_sale_order_line__margin_delivered_percent
 msgid "Margin Delivered Percent"
-msgstr "Porcentage de margen de lo entregado"
+msgstr "Margen entr. (%)"
 
 #. module: sale_margin_delivered
 #: model_terms:ir.ui.view,arch_db:sale_margin_delivered.view_order_form
@@ -41,28 +52,41 @@ msgstr "Margen entr."
 #. module: sale_margin_delivered
 #: model_terms:ir.ui.view,arch_db:sale_margin_delivered.view_order_form
 msgid "Margin dlvd. (%)"
-msgstr "Margen de dlvd. (%)"
+msgstr "Margen entr. (%)"
+
+#. module: sale_margin_delivered
+#: model:ir.model.fields,help:sale_margin_delivered.field_sale_order_line__margin_delivered_percent
+msgid ""
+"Margin percent between the Unit Price with discounts and Delivered Unit Cost.\n"
+"\n"
+"Formula: (Margin Dlvd. / Unit Price with Discounts) * 100.0"
+msgstr ""
+"Margen porcentual entre el Precio Unitario con Descuentos y el Coste Unitario entregado.\n"
+"\n"
+"Fórmula: (Margen entr. / Precio Unitario con Descuentos) * 100,0"
 
 #. module: sale_margin_delivered
 #: model:ir.model.fields,field_description:sale_margin_delivered.field_sale_order_line__purchase_price_delivery
 msgid "Purchase Price Delivery"
-msgstr "Precio de compra Entrega"
+msgstr "Coste entr."
 
 #. module: sale_margin_delivered
 #: model:ir.model,name:sale_margin_delivered.model_sale_report
 msgid "Sales Analysis Report"
-msgstr "Análisis de ventas"
+msgstr "Informe de análisis de ventas"
 
 #. module: sale_margin_delivered
 #: model:ir.model,name:sale_margin_delivered.model_sale_order_line
 msgid "Sales Order Line"
-msgstr "Línea de pedido de ventas"
+msgstr "Líneas de pedido"
 
-#~ msgid "% Margin"
-#~ msgstr "% Margen"
-
-#~ msgid "Margin"
-#~ msgstr "Margen"
-
-#~ msgid "Purchase Price Delivered"
-#~ msgstr "Precio de compra de lo entregado"
+#. module: sale_margin_delivered
+#: model:ir.model.fields,help:sale_margin_delivered.field_sale_order_line__margin_delivered
+msgid ""
+"Total Margin of all delivered products.\n"
+"\n"
+"Formula: Delivered Quantities * (Unit Price with Discounts - Average Unit Cost of Delivered Products)"
+msgstr ""
+"Margen Total de todos los productos entregados.\n"
+"\n"
+"Fórmula: Cantidades Entregadas * (Precio Unitario con Descuentos - Promedio del Coste Unitario de los productos entregados)"

--- a/sale_margin_delivered/i18n/sale_margin_delivered.pot
+++ b/sale_margin_delivered/i18n/sale_margin_delivered.pot
@@ -6,12 +6,22 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-05-31 07:22+0000\n"
+"PO-Revision-Date: 2024-05-31 07:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: sale_margin_delivered
+#: model:ir.model.fields,help:sale_margin_delivered.field_sale_order_line__purchase_price_delivery
+msgid ""
+"Average Unit Cost of delivered products.\n"
+"\n"
+"Formula: Value Delivered / Quantity Delivered"
+msgstr ""
 
 #. module: sale_margin_delivered
 #: model_terms:ir.ui.view,arch_db:sale_margin_delivered.view_order_form
@@ -40,6 +50,14 @@ msgid "Margin dlvd. (%)"
 msgstr ""
 
 #. module: sale_margin_delivered
+#: model:ir.model.fields,help:sale_margin_delivered.field_sale_order_line__margin_delivered_percent
+msgid ""
+"Margin percent between the Unit Price with discounts and Delivered Unit Cost.\n"
+"\n"
+"Formula: (Margin Dlvd. / Unit Price with Discounts) * 100.0"
+msgstr ""
+
+#. module: sale_margin_delivered
 #: model:ir.model.fields,field_description:sale_margin_delivered.field_sale_order_line__purchase_price_delivery
 msgid "Purchase Price Delivery"
 msgstr ""
@@ -52,4 +70,12 @@ msgstr ""
 #. module: sale_margin_delivered
 #: model:ir.model,name:sale_margin_delivered.model_sale_order_line
 msgid "Sales Order Line"
+msgstr ""
+
+#. module: sale_margin_delivered
+#: model:ir.model.fields,help:sale_margin_delivered.field_sale_order_line__margin_delivered
+msgid ""
+"Total Margin of all delivered products.\n"
+"\n"
+"Formula: Delivered Quantities * (Unit Price with Discounts - Average Unit Cost of Delivered Products)"
 msgstr ""

--- a/sale_margin_delivered/readme/CONTRIBUTORS.rst
+++ b/sale_margin_delivered/readme/CONTRIBUTORS.rst
@@ -5,3 +5,6 @@
   * David Vidal
   * Carlos Roca
   * Pilar Vargas
+
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
+* Rafael Blasco (`Moduon <https://www.moduon.team/>`__)

--- a/sale_margin_delivered/static/description/index.html
+++ b/sale_margin_delivered/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -435,12 +435,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pilar Vargas</li>
 </ul>
 </li>
+<li>Eduardo de Miguel (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
+<li>Rafael Blasco (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_margin_delivered/tests/test_sale_margin_delivered.py
+++ b/sale_margin_delivered/tests/test_sale_margin_delivered.py
@@ -88,6 +88,19 @@ class TestSaleMarginDelivered(TransactionCase):
         self.assertEqual(order_line.margin_delivered_percent, 50.0)
         self.assertEqual(order_line.purchase_price_delivery, order_line.purchase_price)
 
+    def test_sale_margin_delivered_excess(self):
+        """Delivered quantities exceed ordered quantities"""
+        sale_order = self._new_sale_order()
+        sale_order.action_confirm()
+        picking = sale_order.picking_ids
+        picking.action_assign()
+        picking.move_line_ids.qty_done = 12.0
+        picking._action_done()
+        order_line = sale_order.order_line[:1]
+        self.assertEqual(order_line.margin_delivered, 120.0)
+        self.assertEqual(order_line.margin_delivered_percent, 50.0)
+        self.assertEqual(order_line.purchase_price_delivery, order_line.purchase_price)
+
     def test_sale_margin_zero(self):
         sale_order = self._new_sale_order()
         order_line = sale_order.order_line[:1]
@@ -95,24 +108,26 @@ class TestSaleMarginDelivered(TransactionCase):
         self.assertEqual(order_line.margin_delivered, 0.0)
         self.assertEqual(order_line.margin_delivered_percent, 0)
 
-    def _create_return(self, picking, to_refund=False):
+    def _create_return(self, picking, qty_refund=3.0, to_refund=False):
         return_wiz = self.get_return_picking_wizard(picking)
-        return_wiz.product_return_moves.write({"quantity": 3.0, "to_refund": to_refund})
+        return_wiz.product_return_moves.write(
+            {"quantity": qty_refund, "to_refund": to_refund}
+        )
         new_picking_id, pick_type_id = return_wiz._create_returns()
         return self.env["stock.picking"].browse(new_picking_id)
 
-    def _validate_so_picking(self, sale_order):
+    def _validate_so_picking(self, sale_order, qty_done=6.0):
         picking = sale_order.picking_ids
         picking.action_assign()
-        picking.move_line_ids.qty_done = 6.0
+        picking.move_line_ids.qty_done = qty_done
         picking._action_done()
         return picking
 
     def test_sale_margin_delivered_return_to_refund(self):
         sale_order = self._new_sale_order()
         sale_order.action_confirm()
-        picking = self._validate_so_picking(sale_order)
-        picking_return = self._create_return(picking, to_refund=True)
+        picking = self._validate_so_picking(sale_order, qty_done=6.0)
+        picking_return = self._create_return(picking, qty_refund=3.0, to_refund=True)
         picking_return.move_line_ids.qty_done = 3.0
         picking_return._action_done()
         order_line = sale_order.order_line[:1]
@@ -120,14 +135,40 @@ class TestSaleMarginDelivered(TransactionCase):
         self.assertEqual(order_line.margin_delivered_percent, 50.0)
         self.assertEqual(order_line.purchase_price_delivery, order_line.purchase_price)
 
+    def test_sale_margin_delivered_return_to_refund_excess(self):
+        """Delivered quantities exceed ordered quantities and return with refund"""
+        sale_order = self._new_sale_order()
+        sale_order.action_confirm()
+        picking = self._validate_so_picking(sale_order, qty_done=12.0)
+        picking_return = self._create_return(picking, qty_refund=3.0, to_refund=True)
+        picking_return.move_line_ids.qty_done = 3.0
+        picking_return._action_done()
+        order_line = sale_order.order_line[:1]
+        self.assertEqual(order_line.margin_delivered, 90.0)
+        self.assertEqual(order_line.margin_delivered_percent, 50.0)
+        self.assertEqual(order_line.purchase_price_delivery, order_line.purchase_price)
+
     def test_sale_margin_delivered_return_no_refund(self):
         sale_order = self._new_sale_order()
         sale_order.action_confirm()
-        picking = self._validate_so_picking(sale_order)
-        picking_return = self._create_return(picking, to_refund=False)
+        picking = self._validate_so_picking(sale_order, qty_done=6.0)
+        picking_return = self._create_return(picking, qty_refund=3.0, to_refund=False)
         picking_return.move_line_ids.qty_done = 3.0
         picking_return._action_done()
         order_line = sale_order.order_line[:1]
         self.assertEqual(order_line.margin_delivered, 60.0)
+        self.assertEqual(order_line.margin_delivered_percent, 50.0)
+        self.assertEqual(order_line.purchase_price_delivery, order_line.purchase_price)
+
+    def test_sale_margin_delivered_return_no_refund_excess(self):
+        """Delivered quantities exceed ordered quantities and return without refund"""
+        sale_order = self._new_sale_order()
+        sale_order.action_confirm()
+        picking = self._validate_so_picking(sale_order, qty_done=12.0)
+        picking_return = self._create_return(picking, qty_refund=3.0, to_refund=False)
+        picking_return.move_line_ids.qty_done = 3.0
+        picking_return._action_done()
+        order_line = sale_order.order_line[:1]
+        self.assertEqual(order_line.margin_delivered, 120.0)
         self.assertEqual(order_line.margin_delivered_percent, 50.0)
         self.assertEqual(order_line.purchase_price_delivery, order_line.purchase_price)


### PR DESCRIPTION
When sending more quantities than ordered, `purchase_price_delivery` field is not calculated correctly in this Odoo version.

Now, instead of use unit_cost of valuation layer, value / quantity is used instead.
Refunds are already taken in consideration in valuation layers.
Before, only the first valuation layer is taken in consideration, now all valuation layers are considered. (FIFO product valuation and one move needs to be splitted in 2 stock.move.lines and each move line has different lots with different values)

Also added tests, more concise translations and "help" to fields to know exactly what does.

https://www.loom.com/share/9cc8c826b8054b62a508d561632b837c?sid=ce29f0dd-9fd4-40bd-b615-4f775f42b339

MT-6136 @moduon @yajo @EmilioPascual  @rafaelbn @sergio-teruel please review if you want :)