### PR TITLE
[16.0][FIX] sale_margin_delivered: Avoid rounding error

### DIFF
--- a/sale_margin_delivered/models/sale_margin.py
+++ b/sale_margin_delivered/models/sale_margin.py
@@ -72,6 +72,10 @@ class SaleOrderLine(models.Model):
         self.margin_delivered_percent = 0.0
         self.purchase_price_delivery = 0.0
         for line in self.filtered("qty_delivered"):
+            # we need to compute the price reduce to avoid rounding issues
+            # the one stored in the line is rounded to the product price precision
+            price_reduce_taxexcl = line.price_subtotal / line.product_uom_qty
+
             if line.product_id.type != "product":
                 currency = line.order_id.pricelist_id.currency_id
                 price = line.purchase_price
@@ -91,13 +95,13 @@ class SaleOrderLine(models.Model):
                 )
                 # Inverse qty_delivered because outgoing quantities are negative
                 line.margin_delivered = -qty_delivered * (
-                    line.price_reduce - line.purchase_price_delivery
+                    price_reduce_taxexcl - line.purchase_price_delivery
                 )
             # compute percent margin based on delivered quantities or ordered
             # quantities
-            if line.price_reduce:
+            if price_reduce_taxexcl:
                 line.margin_delivered_percent = (
-                    (line.price_reduce - line.purchase_price_delivery)
-                    / line.price_reduce
+                    (price_reduce_taxexcl - line.purchase_price_delivery)
+                    / price_reduce_taxexcl
                     * 100.0
                 )

--- a/sale_margin_delivered/views/sale_margin_delivered_view.xml
+++ b/sale_margin_delivered/views/sale_margin_delivered_view.xml
@@ -6,7 +6,7 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale_margin.sale_margin_sale_order_line_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='margin']" position="after">
+            <xpath expr="//field[@name='margin_percent']" position="after">
                 <field
                     name="purchase_price_delivery"
                     string="Cost Price dlvd."


### PR DESCRIPTION
'price_reduce' is deprecated and removed into the next version. Compute
the prirce_reduct from the price_subotal / product_uom_qty. We might
be tempted to use the 'price_reduce_taxecl' field from the sale order
line but this field is rounded by default to the monetary precision.

As an additional benefit this change ensures the compatibility with
the 'sale_triple_discount' addon. Indeed, when
'sale_triple_discount' is installed, the discount field is not used
as an aggregation of all the applied discount. It's only use to store
the first discount applied. Therefore, the field is not properly
computed since it doesn't include the second and third discount.