### PR TITLE
[16.0][IMP] account_invoice_margin_sale: Add post_install hook

### DIFF
--- a/account_invoice_margin_sale/README.rst
+++ b/account_invoice_margin_sale/README.rst
@@ -75,6 +75,7 @@ Contributors
   * Sergio Teruel
   * Carlos Dauden
   * Víctor Martínez
+  * Carolina Fernandez
 
 * `Open Source Integrators <https://www.opensourceintegrators.com>`__:
 

--- a/account_invoice_margin_sale/__init__.py
+++ b/account_invoice_margin_sale/__init__.py
@@ -1,3 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
+from .hooks import post_init_hook
 from . import models

--- a/account_invoice_margin_sale/__manifest__.py
+++ b/account_invoice_margin_sale/__manifest__.py
@@ -15,5 +15,6 @@
     "application": False,
     "installable": True,
     "auto_install": True,
+    "post_init_hook": "post_init_hook",
     "depends": ["sale_margin", "account_invoice_margin"],
 }

--- a/account_invoice_margin_sale/hooks.py
+++ b/account_invoice_margin_sale/hooks.py
@@ -1,0 +1,39 @@
+def post_init_hook(cr, registry):
+    # update purchase_price for invoices from sale_order
+    cr.execute(
+        """
+        UPDATE account_move_line AS aml
+        SET
+            purchase_price = sol.purchase_price,
+            margin = sol.margin,
+            margin_signed = CASE
+                WHEN am.move_type = 'out_refund' THEN sol.margin * -1
+                ELSE sol.margin
+            END,
+            margin_percent = sol.margin_percent * 100
+        FROM sale_order_line sol, account_move am, sale_order_line_invoice_rel rel
+        WHERE am.id = aml.move_id
+            AND rel.order_line_id = sol.id
+            AND rel.invoice_line_id = aml.id;
+        """
+    )
+    # recalculate margin for invoices from sale_order
+    cr.execute(
+        """
+        UPDATE account_move AS am
+        SET
+            margin = aml.sum_margin,
+            margin_signed = aml.sum_margin_signed,
+            margin_percent = aml.sum_margin / am.amount_untaxed * 100
+        FROM (
+            SELECT
+                aml.move_id,
+                SUM(aml.margin) AS sum_margin,
+                SUM(aml.margin_signed) AS sum_margin_signed
+            FROM account_move_line AS aml
+            GROUP BY aml.move_id
+        ) AS aml
+        WHERE am.id = aml.move_id
+        AND am.amount_untaxed > 0.0;
+        """
+    )

--- a/account_invoice_margin_sale/readme/CONTRIBUTORS.rst
+++ b/account_invoice_margin_sale/readme/CONTRIBUTORS.rst
@@ -3,6 +3,7 @@
   * Sergio Teruel
   * Carlos Dauden
   * Víctor Martínez
+  * Carolina Fernandez
 
 * `Open Source Integrators <https://www.opensourceintegrators.com>`__:
 

--- a/account_invoice_margin_sale/static/description/index.html
+++ b/account_invoice_margin_sale/static/description/index.html
@@ -420,6 +420,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Sergio Teruel</li>
 <li>Carlos Dauden</li>
 <li>Víctor Martínez</li>
+<li>Carolina Fernandez</li>
 </ul>
 </li>
 <li><a class="reference external" href="https://www.opensourceintegrators.com">Open Source Integrators</a>:<ul>


### PR DESCRIPTION
- Add post_init_hook to update purchase cost in invoice lines from sale order when installing module.

@Tecnativa
TT49994
@pedrobaeza @victoralmau 