### PR TITLE
[FIX] account_invoice_margin: avoid traceback in invoice

### DIFF
--- a/account_invoice_margin/models/account_invoice.py
+++ b/account_invoice_margin/models/account_invoice.py
@@ -104,7 +104,7 @@ class AccountMoveLine(models.Model):
         for line in self:
             if line.move_id.move_type in ["out_invoice", "out_refund"]:
                 purchase_price = line._get_purchase_price()
-                if line.product_uom_id != line.product_id.uom_id:
+                if line.product_id and line.product_uom_id != line.product_id.uom_id:
                     purchase_price = line.product_id.uom_id._compute_price(
                         purchase_price, line.product_uom_id
                     )


### PR DESCRIPTION
When creating an invoice, associating a product (the uom is associated), deleting the product from the line and saving, an error is obtained:

```
File
"/home/odoo/src/user/margin-analysis/account_invoice_margin/models/account_invoice.py", line 108, in _compute_purchase_price
    purchase_price = line.product_id.uom_id._compute_price(
  File "/home/odoo/src/odoo/addons/uom/models/uom_uom.py", line 247, in
_compute_price
    self.ensure_one()
  File "/home/odoo/src/odoo/odoo/models.py", line 5243, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

This is because it attempts to use the [product's uom](https://github.com/Vauxoo/margin-analysis/blob/15.0/account_invoice_margin/models/account_invoice.py#L108) to calculate the purchase price, and the product is empty.

The product is validated before performing the calculation, to avoid the error.

Functional test **before** the fix

https://youtu.be/ZbEGpCJR-xI

Functional test **after** the fix 

https://youtu.be/W2pW2myxQU8