### PR TITLE
[FIX] product_margin_classification: compute correctly fields in multi company context.

### DIFF
--- a/product_margin_classification/README.rst
+++ b/product_margin_classification/README.rst
@@ -91,6 +91,11 @@ Known issues / Roadmap
   due to the poor design of Odoo product module.
   This issue can be maybe fixed in new version of Odoo.
 
+* This module will not work for products that available on many
+  companies, because this module introduces stored fields, that can
+  not be company dependant, and the fields depends on ``standard_price``
+  that is company dependant.
+
 Bug Tracker
 ===========
 

--- a/product_margin_classification/models/product_product.py
+++ b/product_margin_classification/models/product_product.py
@@ -55,6 +55,9 @@ class Productproduct(models.Model):
     )
     def _compute_theoretical_multi(self):
         for product in self:
+            # Handle special case where self.env.company != product.company_id
+            # we switch in a new context to avoid to have a bad standard price
+            product = product.with_company(product.company_id)
             (
                 product.margin_state,
                 product.theoretical_price,

--- a/product_margin_classification/readme/ROADMAP.rst
+++ b/product_margin_classification/readme/ROADMAP.rst
@@ -2,7 +2,7 @@
   due to the poor design of Odoo product module.
   This issue can be maybe fixed in new version of Odoo.
 
-* This module will not work for products that available on many
+* This module will not work for products that available in several
   companies, because this module introduces stored fields, that can
   not be company dependant, and the fields depends on ``standard_price``
-  that is company dependant.
+  that is company dependent.

--- a/product_margin_classification/readme/ROADMAP.rst
+++ b/product_margin_classification/readme/ROADMAP.rst
@@ -1,3 +1,8 @@
 * This module will not work for variants that have a not null ``price_extra`` value,
   due to the poor design of Odoo product module.
   This issue can be maybe fixed in new version of Odoo.
+
+* This module will not work for products that available on many
+  companies, because this module introduces stored fields, that can
+  not be company dependant, and the fields depends on ``standard_price``
+  that is company dependant.

--- a/product_margin_classification/static/description/index.html
+++ b/product_margin_classification/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -429,6 +430,10 @@ change sale price.</p>
 <li>This module will not work for variants that have a not null <tt class="docutils literal">price_extra</tt> value,
 due to the poor design of Odoo product module.
 This issue can be maybe fixed in new version of Odoo.</li>
+<li>This module will not work for products that available on many
+companies, because this module introduces stored fields, that can
+not be company dependant, and the fields depends on <tt class="docutils literal">standard_price</tt>
+that is company dependant.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
@@ -457,7 +462,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION

new computed and stored fields depends on standard_price that is company dependant. As a result, add a warning in the ROADMAP section, to explicit current module limitation. Ensure that computation is done in the context of the company of the product, to avoid to base computation on bad / null standard prices