### PR TITLE
[16.0][IMP] product_margin_classification: add price actions on product.template list

### DIFF
--- a/product_margin_classification/models/product_product.py
+++ b/product_margin_classification/models/product_product.py
@@ -13,7 +13,7 @@ MARGIN_STATE_SELECTION = [
 ]
 
 
-class Productproduct(models.Model):
+class ProductProduct(models.Model):
     _inherit = "product.product"
 
     # Columns Section

--- a/product_margin_classification/models/product_template.py
+++ b/product_margin_classification/models/product_template.py
@@ -73,10 +73,10 @@ class ProductTemplate(models.Model):
             template.theoretical_difference = variant.theoretical_difference
             template.margin_state = variant.margin_state
         for template in self - unique_variants:
-            template.margin_classification_id = 0.0
+            template.margin_classification_id = False
             template.theoretical_price = 0.0
             template.theoretical_difference = 0.0
-            template.margin_state = 0.0
+            template.margin_state = False
 
     def _inverse_margin_classification_id(self):
         for template in self:
@@ -88,3 +88,12 @@ class ProductTemplate(models.Model):
     # Custom Section
     def use_theoretical_price(self):
         self.mapped("product_variant_ids").use_theoretical_price()
+
+    def apply_theoretical_price(self):
+        self.mapped("product_variant_ids").apply_theoretical_price()
+
+    def apply_theoretical_price_too_cheap(self):
+        self.mapped("product_variant_ids").apply_theoretical_price_too_cheap()
+
+    def apply_theoretical_price_too_expensive(self):
+        self.mapped("product_variant_ids").apply_theoretical_price_too_expensive()

--- a/product_margin_classification/tests/__init__.py
+++ b/product_margin_classification/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_product_margin_classification
 from . import test_product_product
+from . import test_product_template

--- a/product_margin_classification/tests/test_product_template.py
+++ b/product_margin_classification/tests/test_product_template.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo.tests.common import TransactionCase
+
+
+# this is a copy of TestProductProduct, changed to work with product.template
+# records.
+class TestProductTemplate(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.too_cheap = cls.env.ref(
+            "product_margin_classification.too_cheap_product"
+        ).product_tmpl_id
+        cls.too_expensive = cls.env.ref(
+            "product_margin_classification.too_expensive_product"
+        ).product_tmpl_id
+        cls.both = cls.too_cheap | cls.too_expensive
+
+    def test_00_prices_not_equal(self):
+        """A simple sanity check."""
+        self.assertNotAlmostEqual(
+            self.too_cheap.list_price,
+            self.too_cheap.theoretical_price,
+        )
+        self.assertNotAlmostEqual(
+            self.too_expensive.list_price,
+            self.too_expensive.theoretical_price,
+        )
+
+    def test_01_action_apply_theoretical_price(self):
+        action = self.env.ref(
+            "product_margin_classification"
+            ".action_product_template_apply_theoretical_price"
+        )
+        action.with_context(
+            active_model="product.template",
+            active_ids=self.both.ids,
+        ).run()
+        self.assertAlmostEqual(
+            self.too_cheap.list_price,
+            self.too_cheap.theoretical_price,
+        )
+        self.assertAlmostEqual(
+            self.too_expensive.list_price,
+            self.too_expensive.theoretical_price,
+        )
+
+    def test_02_action_apply_theoretical_price_too_cheap(self):
+        action = self.env.ref(
+            "product_margin_classification"
+            ".action_product_template_apply_theoretical_price_too_cheap"
+        )
+        action.with_context(
+            active_model="product.template",
+            active_ids=self.both.ids,
+        ).run()
+        self.assertAlmostEqual(
+            self.too_cheap.list_price,
+            self.too_cheap.theoretical_price,
+        )
+        self.assertNotAlmostEqual(
+            self.too_expensive.list_price,
+            self.too_expensive.theoretical_price,
+        )
+
+    def test_03_action_apply_theoretical_price_too_expensive(self):
+        action = self.env.ref(
+            "product_margin_classification"
+            ".action_product_template_apply_theoretical_price_too_expensive"
+        )
+        action.with_context(
+            active_model="product.template",
+            active_ids=self.both.ids,
+        ).run()
+        self.assertNotAlmostEqual(
+            self.too_cheap.list_price,
+            self.too_cheap.theoretical_price,
+        )
+        self.assertAlmostEqual(
+            self.too_expensive.list_price,
+            self.too_expensive.theoretical_price,
+        )

--- a/product_margin_classification/views/view_product_product.xml
+++ b/product_margin_classification/views/view_product_product.xml
@@ -158,4 +158,5 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="state">code</field>
         <field name="code">records.apply_theoretical_price_too_expensive()</field>
     </record>
+
 </odoo>

--- a/product_margin_classification/views/view_product_template.xml
+++ b/product_margin_classification/views/view_product_template.xml
@@ -45,4 +45,43 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         </field>
     </record>
 
+    <record
+        id="action_product_template_apply_theoretical_price"
+        model="ir.actions.server"
+    >
+        <field name="name">Apply Theoretical Price</field>
+        <field name="groups_id" eval="[Command.link(ref('base.group_user'))]" />
+        <field name="model_id" ref="product.model_product_template" />
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">records.apply_theoretical_price()</field>
+    </record>
+
+    <record
+        id="action_product_template_apply_theoretical_price_too_cheap"
+        model="ir.actions.server"
+    >
+        <field name="name">Apply Up To Theoretical Price</field>
+        <field name="groups_id" eval="[Command.link(ref('base.group_user'))]" />
+        <field name="model_id" ref="product.model_product_template" />
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">records.apply_theoretical_price_too_cheap()</field>
+    </record>
+
+    <record
+        id="action_product_template_apply_theoretical_price_too_expensive"
+        model="ir.actions.server"
+    >
+        <field name="name">Apply Down To Theoretical Price</field>
+        <field name="groups_id" eval="[Command.link(ref('base.group_user'))]" />
+        <field name="model_id" ref="product.model_product_template" />
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">records.apply_theoretical_price_too_expensive()</field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
make theoretical price actions available on the `product.template` list instead of only on the `product.product` list.