### PR TITLE
[18.0][FIX] account_invoice_margin: Remove product_cost_security.group_product_edit_cost from tests

### DIFF
--- a/account_invoice_margin/tests/test_account_invoice_margin.py
+++ b/account_invoice_margin/tests/test_account_invoice_margin.py
@@ -11,14 +11,8 @@ class TestAccountInvoiceMargin(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env.user.groups_id |= cls.env.ref(
-            "product_cost_security.group_product_edit_cost"
-        )
-        cls.env.user.groups_id |= cls.env.ref(
-            "product_cost_security.group_product_cost"
-        )
         cls.product_a.lst_price = 200
-        cls.product_a.standard_price = 100
+        cls.product_a.sudo().write({"standard_price": 100})
         cls.invoice = cls.init_invoice(
             "out_invoice",
             partner=cls.partner_a,


### PR DESCRIPTION
Without this change, the test fails. 
`account_invoice_margin` does not depend on `product_cost_security`

```
ERROR: setUpClass (odoo.addons.account_invoice_margin.tests.test_account_invoice_margin.TestAccountInvoiceMargin)
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/tools/cache.py", line 103, in lookup
    r = d[key]
  File "<decorator-gen-6>", line 2, in __getitem__
  File "/opt/odoo/custom/src/odoo/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/tools/lru.py", line 33, in __getitem__
    a = self.d[obj]
KeyError: ('ir.model.data', <function IrModelData._xmlid_lookup at 0x7046b242d7e0>, 'product_cost_security.group_product_edit_cost')
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/account_invoice_margin/tests/test_account_invoice_margin.py", line 14, in setUpClass
    cls.env.user.groups_id |= cls.env.ref(
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 660, in ref
    res_model, res_id = self['ir.model.data']._xmlid_to_res_model_res_id(
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 2292, in _xmlid_to_res_model_res_id
    return self._xmlid_lookup(xmlid)
  File "<decorator-gen-44>", line 2, in _xmlid_lookup
  File "/opt/odoo/custom/src/odoo/odoo/tools/cache.py", line 110, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 2285, in _xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
ValueError: External ID not found in the system: product_cost_security.group_product_edit_cost
```
@pedrobaeza can you review please.

@Tecnativa