### PR TITLE
[IMP] product_margin_classification: Use new check_company feature

### DIFF
--- a/product_margin_classification/demo/product_margin_classification.xml
+++ b/product_margin_classification/demo/product_margin_classification.xml
@@ -10,6 +10,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="markup">50</field>
         <field name="name">Normal Margin (33%)</field>
         <field name="price_round">0.05</field>
+        <field name="company_id" eval="False" />
 
     </record>
 
@@ -18,6 +19,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="name">Big Margin (50%, with 95 cents)</field>
         <field name="price_round">1</field>
         <field name="price_surcharge">-0.05</field>
+        <field name="company_id" eval="False" />
     </record>
 
 </odoo>

--- a/product_margin_classification/models/product_product.py
+++ b/product_margin_classification/models/product_product.py
@@ -20,6 +20,7 @@ class ProductProduct(models.Model):
     margin_classification_id = fields.Many2one(
         comodel_name="product.margin.classification",
         string="Margin Classification",
+        check_company=True,
     )
 
     theoretical_price = fields.Float(

--- a/product_margin_classification/models/product_template.py
+++ b/product_margin_classification/models/product_template.py
@@ -17,6 +17,7 @@ class ProductTemplate(models.Model):
         inverse="_inverse_margin_classification_id",
         search="_search_margin_classification_id",
         comodel_name="product.margin.classification",
+        check_company=True,
     )
 
     theoretical_price = fields.Float(

--- a/product_margin_classification/tests/test_product_margin_classification.py
+++ b/product_margin_classification/tests/test_product_margin_classification.py
@@ -93,6 +93,7 @@ class TestProductMarginClassification(common.TransactionCase):
             {
                 "name": "Template Name",
                 "margin_classification_id": self.classification_big_margin,
+                "company_id": False,
             }
         )
         self.assertEqual(


### PR DESCRIPTION
Trivial PR : avoid to link product of company 1 with margin classification of company 2