### PR TITLE
[18.0][FIX] sale_margin_pricelist_computation: Use sale.order.line _get_margin_pricelist_eval_context to test pricelist.item eval context

### DIFF
--- a/sale_margin_pricelist_computation/models/product_pricelist_item.py
+++ b/sale_margin_pricelist_computation/models/product_pricelist_item.py
@@ -1,6 +1,5 @@
 from odoo import Command, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.tools.float_utils import float_compare
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -22,17 +21,23 @@ class PricelistItem(models.Model):
             if not rec.margin_cost_price_formula and rec.margin_cost_price_formula:
                 continue
             if rec.margin_sale_price_formula:
-                self._eval_python_code_margin_formula(rec.margin_sale_price_formula)
+                rec._eval_python_code_margin_formula(rec.margin_sale_price_formula)
             if rec.margin_cost_price_formula:
-                self._eval_python_code_margin_formula(rec.margin_cost_price_formula)
+                rec._eval_python_code_margin_formula(rec.margin_cost_price_formula)
 
     def _eval_python_code_margin_formula(self, test_string):
-        main_product = self.env["product.product"].new(
+        pricelist = self.env["product.pricelist"].new({"name": "Test Pricelist"})
+        pricelist_item = self.env["product.pricelist.item"].new(
             {
-                "name": "Main Product",
-                "list_price": 35.0,
-                "standard_price": 11.52,
+                "pricelist_id": pricelist.id,
+                "applied_on": "3_global",
+                "base": "list_price",
+                "compute_price": "percentage",
+                "percent_price": 10,
             }
+        )
+        main_product = self.env["product.product"].new(
+            {"name": "Main Product", "list_price": 35.0, "standard_price": 11.52}
         )
         order = self.env["sale.order"].new(
             {
@@ -43,35 +48,13 @@ class PricelistItem(models.Model):
                             "product_id": main_product.id,
                             "product_uom_qty": 2.0,
                             "price_unit": 35.0,
+                            "pricelist_item_id": pricelist_item,
                         }
                     )
                 ],
             }
         )
-        pricelist = self.env["product.pricelist"].new(
-            {
-                "name": "Test Pricelist",
-            }
-        )
-        pricelist_item = self.env["product.pricelist.item"].new(
-            {
-                "pricelist_id": pricelist.id,
-                "applied_on": "3_global",
-                "base": "list_price",
-                "compute_price": "percentage",
-                "percent_price": 10,
-            }
-        )
-        test_eval_context = {
-            "env": self.env,
-            "context": self.env.context,
-            "user": self.env.user,
-            "line": order.order_line,
-            "pricelist": pricelist,
-            "pricelist_item": pricelist_item,
-            "product": main_product,
-            "float_compare": float_compare,
-        }
+        test_eval_context = order.order_line._get_margin_pricelist_eval_context()
         try:
             safe_eval(
                 str(test_string).strip(),

--- a/sale_margin_pricelist_computation/tests/test_sale_margin_pricelist_computation.py
+++ b/sale_margin_pricelist_computation/tests/test_sale_margin_pricelist_computation.py
@@ -1,3 +1,4 @@
+from odoo.exceptions import ValidationError
 from odoo.fields import Command
 
 from odoo.addons.sale_margin.tests.test_sale_margin import TestSaleMargin
@@ -58,3 +59,12 @@ class TestSaleMarginPricelistComputation(TestSaleMargin):
         order = self._create_order(20)
         self.assertAlmostEqual(order.margin, 533.4, delta=0.1)
         self.assertAlmostEqual(order.margin_percent, 0.89, delta=0.1)
+
+    def test_pricelist_item_formula_with_eval_context(self):
+        formula = "result = product.list_price_test"
+        with self.assertRaises(ValidationError):
+            self.margin_pricelist.item_ids[0].write(
+                {"margin_sale_price_formula": formula}
+            )
+        formula = "result = product.list_price / line.product_uom_qty + 10"
+        self.margin_pricelist.item_ids[0].write({"margin_sale_price_formula": formula})


### PR DESCRIPTION
This change allows `_get_margin_pricelist_eval_context` to be overridden from other modules, making it possible to extend the evaluation context for each margin formula and evaluate the formula directly from `pricelist.item`.

@pedrobaeza can you review please?

@Tecnativa