### PR TITLE
[FIX] account_invoice_margin: hide margin fields in 'in' invoices / refund form view.

### DIFF
--- a/account_invoice_margin/views/account_invoice_margin_view.xml
+++ b/account_invoice_margin/views/account_invoice_margin_view.xml
@@ -38,24 +38,29 @@
                 <field
                     name="purchase_price"
                     groups="account_invoice_margin.group_account_invoice_margin_security"
+                    attrs="{'invisible': [('parent.move_type', 'not in', ('out_invoice', 'out_refund'))]}"
                 />
                 <field
                     name="margin"
                     groups="account_invoice_margin.group_account_invoice_margin_security"
+                    attrs="{'invisible': [('parent.move_type', 'not in', ('out_invoice', 'out_refund'))]}"
                 />
                 <field
                     name="margin_percent"
                     groups="account_invoice_margin.group_account_invoice_margin_security"
+                    attrs="{'invisible': [('parent.move_type', 'not in', ('out_invoice', 'out_refund'))]}"
                 />
             </xpath>
             <field name="tax_totals" position="before">
                 <field
                     name="margin"
                     groups="account_invoice_margin.group_account_invoice_margin_security"
+                    attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}"
                 />
                 <field
                     name="margin_percent"
                     groups="account_invoice_margin.group_account_invoice_margin_security"
+                    attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}"
                 />
             </field>
         </field>


### PR DESCRIPTION


Rational: for the time being, margin fields are hidden in the invoice_line_ids tree view (of the invoice form view), but not in the form view. Also total margin and margin percent display in 'in' invoices. This PR harmonizes the display.

@sergio-teruel : could you take a look on this trivial one ? 

thanks ! 